### PR TITLE
prevent SEGFAULT on EOF (^D)

### DIFF
--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -241,7 +241,7 @@ void Thread::getLine()
 	}
 	line = el_gets(el, &linelen);
 	linepos = 0;
-	if (strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
+	if (!line || strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
 	if (line && linelen) {
 		history(myhistory, &ev, H_ENTER, line);
 		history(myhistory, &ev, H_SAVE, historyfilename);

--- a/src/VM.cpp
+++ b/src/VM.cpp
@@ -242,7 +242,7 @@ void Thread::getLine()
 	line = el_gets(el, &linelen);
 	linepos = 0;
 	if (!line || strncmp(line, "quit", 4)==0 || strncmp(line, "..", 2)==0) { line = NULL; throw errUserQuit; }
-	if (line && linelen) {
+	if (linelen > 0) {
 		history(myhistory, &ev, H_ENTER, line);
 		history(myhistory, &ev, H_SAVE, historyfilename);
 		if (logfilename) {


### PR DESCRIPTION
If the user attempts to terminate the repl with ^d (causing EOF on `stdin`) the `sapf` app crashes with a segmentation fault.  This patch resolves that.